### PR TITLE
fix(options): allow allowed-direct-imports to be specified

### DIFF
--- a/pylint_import_modules/__init__.py
+++ b/pylint_import_modules/__init__.py
@@ -49,6 +49,7 @@ class ImportOnlyModulesChecked(checkers.BaseChecker):
             'allowed-direct-imports',
             dict(
                 metavar='module1.{import1,import2},module2.import3',
+                type='string',
                 default='',
                 help='A comma-separated list of exceptions. '
                 'Imports from the same module can be factorized in curly braces',


### PR DESCRIPTION
@bayesimpact thanks for turning this into a module! I was just investigating getting this set up for my team and lo-and-behold you've created a package for exactly what I need. Thanks!

This changeset fixes the following:

```
$ pylint --load-plugins=pylint_import_modules --allowed-direct-imports="typing.Any" *.py
Usage:  pylint [options] modules_or_packages

  Check that module(s) satisfy a coding standard (and more !).

    pylint --help

  Display this help message and exit.

    pylint --help-msg <msg-id>[,<msg-id>]

  Display help messages about given message identifiers and exit.

pylint: error: --allowed-direct-imports option does not take a value
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/pylint_import_modules/6)
<!-- Reviewable:end -->
