### PR TITLE
feat(options): add support for globally allowing direct imports

### DIFF
--- a/pylint_import_modules/__init__.py
+++ b/pylint_import_modules/__init__.py
@@ -1,8 +1,9 @@
 # From https://gist.github.com/jobevers/49432f6751753cfffea3cd2cddaaa183
 # Credit to mitar on stackoverflow: https://stackoverflow.com/a/45390670/2752242
 
+import collections
 import re
-from typing import List, Tuple
+from typing import Dict, Set
 
 import astroid
 from pylint import checkers, interfaces
@@ -12,18 +13,19 @@ _CONFIG_HEAD_REGEX = re.compile(r',|\.(?={)')
 
 
 # TODO(cyrille): Add relevant error messages for wrong config.
-def _parse_config(config: str) -> List[Tuple[str, str]]:
+def _parse_config(config: str) -> Dict[str, Set[str]]:
+    res = collections.defaultdict(set)
     if not config:
-        return []
+        return res
     config = re.sub(r'\s+', '', config) + ','
-    res = []
     while config:
         module, config = _CONFIG_HEAD_REGEX.split(config, 1)
         if not config.startswith('{'):
-            res.append(tuple(module.rsplit('.', 1)))
+            module, import_ = module.rsplit('.', 1)
+            res[module].add(import_)
             continue
         submodules, config = config[1:].split('},', 1)
-        res.extend((module, submodule) for submodule in submodules.split(','))
+        res[module].update(submodules.split(','))
     return res
 
 
@@ -62,7 +64,7 @@ class ImportOnlyModulesChecked(checkers.BaseChecker):
         self._exceptions = None
 
     @property
-    def exceptions(self):
+    def exceptions(self) -> Dict[str, Set[str]]:
         if self._exceptions is None:
             self._exceptions = _parse_config(self.config.allowed_direct_imports)
         return self._exceptions
@@ -79,7 +81,7 @@ class ImportOnlyModulesChecked(checkers.BaseChecker):
         if name not in self._imports_to_check:
             return
         module_name = self._imports_to_check[name]
-        if (module_name, node.attrname) in self.exceptions:
+        if self.exceptions[module_name] & {node.attrname, '*'}:
             self.add_message(
                 'import-direct-attributes',
                 node=node,
@@ -87,7 +89,7 @@ class ImportOnlyModulesChecked(checkers.BaseChecker):
 
     def visit_import(self, node):
         for (name, alias) in node.names:
-            if name in (module for module, attribute in self.exceptions):
+            if name in self.exceptions:
                 self._imports_to_check[alias or name] = name
 
     @utils.check_messages('import-only-modules')
@@ -112,10 +114,10 @@ class ImportOnlyModulesChecked(checkers.BaseChecker):
                 imported_module.import_module(name, True)
                 # Good, we could import "name" as a module relative to the "imported_module".
                 full_name = f'{modname}.{name}'
-                if full_name in (module for module, attribute in self.exceptions):
+                if full_name in self.exceptions:
                     self._imports_to_check[alias or name] = full_name
             except astroid.AstroidImportError:
-                if (modname, name) in self.exceptions:
+                if self.exceptions[modname] & {name, '*'}:
                     # The non-module import is one of the allowed ones.
                     continue
                 self.add_message(


### PR DESCRIPTION
This changeset enables support for allowing any direct imports for a
given package with: `--allowed-direct-imports="typing.*"`.

This helps us support, eg. the Google Style Guide, where the `typing`
module is not meant to be effected by the "only import modules" rule.
[Source](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#22-imports).

For best results, this should be merged after #6, though there's no
explicit dependency.

---

`_parse_config` could be kept as a `List[Tuple[str, str]]` instead of a
`Dict[str, Set[str]]` if you prefer -- switching the format made parsing
easier but the changeset could easily be refactored to avoid the need.

This changeset marks `--allowed-direct-imports="typing.*,..."` as allowing
any direct imports from the `typing` package, but an alternative would
be to instead allow `--allowed-direct-imports="typing,..."`. I'm ambivalent
on the API here -- if you'd prefer the latter (or any other format), I'd be
happy to switch this around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/pylint_import_modules/7)
<!-- Reviewable:end -->
